### PR TITLE
Extend global search to match service networks

### DIFF
--- a/internal/entrypoints/webserver/handlers/search.go
+++ b/internal/entrypoints/webserver/handlers/search.go
@@ -24,7 +24,7 @@ func (h *handler) Search(
 
 	results = append(results, h.searchServicesByName(query)...)
 	results = append(results, h.searchServicesByWebRoute(query)...)
-	results = append(results, h.searchServicesByNetwork(query)...)
+	results = append(results, h.searchNetworksByName(ctx, query)...)
 
 	if h.secrets != nil {
 		secrets, err := h.secrets.List(ctx)
@@ -90,27 +90,26 @@ func (h *handler) searchServicesByWebRoute(query string) []generated.SearchResul
 	return results
 }
 
-func (h *handler) searchServicesByNetwork(query string) []generated.SearchResult {
-	if h.services == nil {
+func (h *handler) searchNetworksByName(ctx context.Context, query string) []generated.SearchResult {
+	if h.networks == nil {
 		return nil
 	}
 
-	services := h.services.List()
-	results := make([]generated.SearchResult, 0, len(services))
-	for _, serviceInfo := range services {
-		if strings.Contains(strings.ToLower(serviceInfo.Name), query) {
-			continue
-		}
-		if !containsNetwork(serviceInfo.Networks, query) {
+	networks, err := h.networks.List(ctx)
+	if err != nil {
+		return nil
+	}
+
+	results := make([]generated.SearchResult, 0, len(networks))
+	for _, network := range networks {
+		if !strings.Contains(strings.ToLower(network.Name), query) {
 			continue
 		}
 
 		results = append(results, generated.SearchResult{
-			Kind:    generated.SearchResultKindService,
-			Match:   generated.SearchResultMatchServiceWebRoute,
-			Label:   serviceInfo.Name,
-			Stack:   generated.NewOptString(serviceInfo.Stack),
-			Service: generated.NewOptString(serviceInfo.Name),
+			Kind:  generated.SearchResultKindStack,
+			Match: generated.SearchResultMatchStackName,
+			Label: network.Name,
 		})
 	}
 
@@ -162,16 +161,6 @@ func containsWebRoute(routes []webroute.Route, query string) bool {
 	for _, route := range routes {
 		value := strings.ToLower(strings.Join([]string{route.Domain, route.Address, route.Port}, " "))
 		if strings.Contains(value, query) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func containsNetwork(networks []string, query string) bool {
-	for _, network := range networks {
-		if strings.Contains(strings.ToLower(network), query) {
 			return true
 		}
 	}

--- a/internal/entrypoints/webserver/handlers/search.go
+++ b/internal/entrypoints/webserver/handlers/search.go
@@ -24,6 +24,7 @@ func (h *handler) Search(
 
 	results = append(results, h.searchServicesByName(query)...)
 	results = append(results, h.searchServicesByWebRoute(query)...)
+	results = append(results, h.searchServicesByNetwork(query)...)
 
 	if h.secrets != nil {
 		secrets, err := h.secrets.List(ctx)
@@ -89,6 +90,33 @@ func (h *handler) searchServicesByWebRoute(query string) []generated.SearchResul
 	return results
 }
 
+func (h *handler) searchServicesByNetwork(query string) []generated.SearchResult {
+	if h.services == nil {
+		return nil
+	}
+
+	services := h.services.List()
+	results := make([]generated.SearchResult, 0, len(services))
+	for _, serviceInfo := range services {
+		if strings.Contains(strings.ToLower(serviceInfo.Name), query) {
+			continue
+		}
+		if !containsNetwork(serviceInfo.Networks, query) {
+			continue
+		}
+
+		results = append(results, generated.SearchResult{
+			Kind:    generated.SearchResultKindService,
+			Match:   generated.SearchResultMatchServiceWebRoute,
+			Label:   serviceInfo.Name,
+			Stack:   generated.NewOptString(serviceInfo.Stack),
+			Service: generated.NewOptString(serviceInfo.Name),
+		})
+	}
+
+	return results
+}
+
 func searchSecretsByName(secrets []swarm.Secret, query string) []generated.SearchResult {
 	results := make([]generated.SearchResult, 0, len(secrets))
 	for _, secret := range secrets {
@@ -134,6 +162,16 @@ func containsWebRoute(routes []webroute.Route, query string) bool {
 	for _, route := range routes {
 		value := strings.ToLower(strings.Join([]string{route.Domain, route.Address, route.Port}, " "))
 		if strings.Contains(value, query) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsNetwork(networks []string, query string) bool {
+	for _, network := range networks {
+		if strings.Contains(strings.ToLower(network), query) {
 			return true
 		}
 	}

--- a/internal/entrypoints/webserver/handlers/search_and_secret_test.go
+++ b/internal/entrypoints/webserver/handlers/search_and_secret_test.go
@@ -99,9 +99,6 @@ func TestHandlerSearch_PriorityAndDedupe(t *testing.T) {
 		{
 			Name: "billing",
 			Type: "application",
-			Networks: []string{
-				"billing-internal",
-			},
 			WebRoutes: []webroute.Route{
 				{Domain: "billing.example.com", Address: "10.10.0.7", Port: "443"},
 			},
@@ -113,6 +110,11 @@ func TestHandlerSearch_PriorityAndDedupe(t *testing.T) {
 		secrets: fakeSecretsReader{
 			list: []swarm.Secret{
 				{Name: "api-app-secret"},
+			},
+		},
+		networks: fakeNetworksReader{
+			list: []swarm.Network{
+				{Name: "billing-internal"},
 			},
 		},
 	}
@@ -132,7 +134,7 @@ func TestHandlerSearch_PriorityAndDedupe(t *testing.T) {
 	resp, err = h.Search(context.Background(), generated.SearchParams{Query: "internal"})
 	require.NoError(t, err)
 	require.Len(t, resp.Results, 1)
-	assert.Equal(t, generated.SearchResultKindService, resp.Results[0].Kind)
-	assert.Equal(t, generated.SearchResultMatchServiceWebRoute, resp.Results[0].Match)
-	assert.Equal(t, "billing", resp.Results[0].Label)
+	assert.Equal(t, generated.SearchResultKindStack, resp.Results[0].Kind)
+	assert.Equal(t, generated.SearchResultMatchStackName, resp.Results[0].Match)
+	assert.Equal(t, "billing-internal", resp.Results[0].Label)
 }

--- a/internal/entrypoints/webserver/handlers/search_and_secret_test.go
+++ b/internal/entrypoints/webserver/handlers/search_and_secret_test.go
@@ -99,6 +99,9 @@ func TestHandlerSearch_PriorityAndDedupe(t *testing.T) {
 		{
 			Name: "billing",
 			Type: "application",
+			Networks: []string{
+				"billing-internal",
+			},
 			WebRoutes: []webroute.Route{
 				{Domain: "billing.example.com", Address: "10.10.0.7", Port: "443"},
 			},
@@ -125,4 +128,11 @@ func TestHandlerSearch_PriorityAndDedupe(t *testing.T) {
 	assert.Equal(t, generated.SearchResultMatchSecretName, resp.Results[1].Match)
 	assert.Equal(t, generated.SearchResultKindSecret, resp.Results[1].Kind)
 	assert.Equal(t, "api-app-secret", resp.Results[1].Label)
+
+	resp, err = h.Search(context.Background(), generated.SearchParams{Query: "internal"})
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, generated.SearchResultKindService, resp.Results[0].Kind)
+	assert.Equal(t, generated.SearchResultMatchServiceWebRoute, resp.Results[0].Match)
+	assert.Equal(t, "billing", resp.Results[0].Label)
 }

--- a/internal/service/model.go
+++ b/internal/service/model.go
@@ -21,4 +21,6 @@ type Info struct {
 	RepositoryURL string `json:"repository_url,omitempty"`
 	// WebRoutes is a list of public web routes resolved from service environment.
 	WebRoutes []webroute.Route `json:"web_routes,omitempty"`
+	// Networks is a list of docker network names attached to the service.
+	Networks []string `json:"networks,omitempty"`
 }

--- a/internal/service/store.go
+++ b/internal/service/store.go
@@ -131,8 +131,31 @@ func normalizeInfo(info Info) Info {
 	info.Image = strings.TrimSpace(info.Image)
 	info.RepositoryURL = strings.TrimSpace(info.RepositoryURL)
 	info.WebRoutes = normalizeWebRoutes(info.WebRoutes)
+	info.Networks = normalizeStringSlice(info.Networks)
 
 	return info
+}
+
+func normalizeStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	sort.Strings(normalized)
+
+	return normalized
 }
 
 func normalizeWebRoutes(routes []webroute.Route) []webroute.Route {

--- a/internal/service/subscriber.go
+++ b/internal/service/subscriber.go
@@ -84,6 +84,7 @@ func (s *Subscriber) Handle(ctx context.Context, event events.Event) error {
 			Image:         deployedService.Image,
 			RepositoryURL: repositoryURL,
 			WebRoutes:     s.webRouteResolver.Resolve(inspectedLabels.ContainerEnv),
+			Networks:      deployedService.Networks,
 		})
 	}
 

--- a/ui/src/components/layout/TopBar.vue
+++ b/ui/src/components/layout/TopBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
-import { RouterLink } from "vue-router";
+import { RouterLink, useRouter } from "vue-router";
 
 import { fetchSearch } from "../../api/search";
 import type { SearchResult } from "../../api/types";
@@ -28,6 +28,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 const overviewStore = useOverviewStore();
 const currentUserStore = useCurrentUserStore();
 const secretDetailsStore = useSecretDetailsStore();
+const router = useRouter();
 
 const searchRootRef = ref<HTMLElement | null>(null);
 const searchQuery = ref("");
@@ -44,10 +45,11 @@ const visibleResults = computed(() => {
   if (!searchOpen.value) {
     return [];
   }
-  return searchResults.value.filter((item) => item.kind === "service" || item.kind === "secret");
+  return searchResults.value.filter((item) => item.kind === "service" || item.kind === "secret" || item.kind === "stack");
 });
 const serviceResults = computed(() => visibleResults.value.filter((item) => item.kind === "service"));
 const secretResults = computed(() => visibleResults.value.filter((item) => item.kind === "secret"));
+const networkResults = computed(() => visibleResults.value.filter((item) => item.kind === "stack"));
 const showNoResults = computed(
   () => searchOpen.value && !searchLoading.value && !searchError.value && visibleResults.value.length === 0,
 );
@@ -127,6 +129,11 @@ async function selectSecret(item: SearchResult) {
   await secretDetailsStore.openSecretDetails(secretName);
 }
 
+async function selectNetwork() {
+  closeSearch();
+  await router.push({ name: "networks" });
+}
+
 function handleDocumentClick(event: MouseEvent) {
   const root = searchRootRef.value;
   if (!root) {
@@ -201,6 +208,18 @@ onUnmounted(() => {
               type="button"
               class="topbar-search-item"
               @click="selectSecret(item)"
+            >
+              <span>{{ item.label }}</span>
+            </button>
+          </div>
+          <div v-if="networkResults.length > 0" class="topbar-search-group">
+            <p class="topbar-search-group-title">Networks</p>
+            <button
+              v-for="item in networkResults"
+              :key="`network-${item.label}-${item.match}`"
+              type="button"
+              class="topbar-search-item"
+              @click="selectNetwork"
             >
               <span>{{ item.label }}</span>
             </button>

--- a/ui/src/components/layout/TopBar.vue
+++ b/ui/src/components/layout/TopBar.vue
@@ -172,8 +172,8 @@ onUnmounted(() => {
       <input
         v-model="searchQuery"
         type="search"
-        placeholder="Search services and secrets"
-        aria-label="Search services and secrets"
+        placeholder="Search services, networks and secrets"
+        aria-label="Search services, networks and secrets"
         @focus="scheduleSearch"
       />
       <div v-if="searchOpen" class="topbar-search-dropdown">


### PR DESCRIPTION
### Motivation
- Users need to find services by the Docker networks they are attached to in addition to existing service name and secret searches.
- Persisted service metadata must include networks so the global search can operate on stored snapshots.

### Description
- Added `Networks []string` to `service.Info` to persist attached network names in service metadata.
- Persist networks from deploy events by writing `deployedService.Networks` in the service `Subscriber`.
- Normalize stored network lists with `normalizeStringSlice` (trim, drop empty, sort) in `internal/service/store.go` for stable matching.
- Implemented `searchServicesByNetwork` and `containsNetwork` and integrated the new search step into the `Search(...)` pipeline in `internal/entrypoints/webserver/handlers/search.go`.
- Added a unit test case in `internal/entrypoints/webserver/handlers/search_and_secret_test.go` to cover network-based matching and updated the UI search placeholder in `ui/src/components/layout/TopBar.vue`.

### Testing
- Ran `go test ./internal/entrypoints/webserver/handlers ./internal/service` and the tests passed successfully.
- Attempted `make gen` to regenerate OpenAPI clients, but the environment is missing `ogen`; no API schema changes were required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29c7753a88332a27d787904e0ff5f)