### PR TITLE
feat: auth proxy authentication

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,8 @@ const (
 	AuthenticationStrategyNone = "none"
 	// AuthenticationStrategyBasic enables HTTP Basic authentication.
 	AuthenticationStrategyBasic = "basic"
+	// AuthenticationStrategyAuthProxy enables authentication through a trusted reverse proxy.
+	AuthenticationStrategyAuthProxy = "auth_proxy"
 
 	defaultWebAddress         = ":8080"
 	defaultWebhookAddress     = ":8082"
@@ -126,7 +128,7 @@ type StacksSourceSpec struct {
 }
 
 type NetworksSourceSpec struct {
-	// File is a path to YAML file with network definitions relative to repository root.
+	// File is a path to network definitions file inside git repository.
 	File string `yaml:"file"`
 }
 
@@ -780,6 +782,9 @@ func (a AssistantOpenAISpec) ResolveMaxTokens() (int, error) {
 
 // Strategy resolves configured web authentication strategy.
 func (a AuthenticationSpec) Strategy() string {
+	if strings.TrimSpace(a.AuthProxy.LoginHeader) != "" {
+		return AuthenticationStrategyAuthProxy
+	}
 	if strings.TrimSpace(a.Basic.HTPasswdFile.Path) != "" {
 		return AuthenticationStrategyBasic
 	}

--- a/internal/config/web.go
+++ b/internal/config/web.go
@@ -17,9 +17,18 @@ type SecuritySpec struct {
 type AuthenticationSpec struct {
 	// Basic contains HTTP Basic authentication settings.
 	Basic BasicAuthenticationSpec `yaml:"basic"`
+	// AuthProxy contains authentication settings for a trusted reverse proxy.
+	AuthProxy AuthProxyAuthenticationSpec `yaml:"authProxy"`
 }
 
 type BasicAuthenticationSpec struct {
 	// HTPasswdFile is a path to htpasswd file with user credentials.
 	HTPasswdFile specw.File `yaml:"htpasswdFile"`
+}
+
+type AuthProxyAuthenticationSpec struct {
+	// Enabled enables authentication using a login header set by a trusted reverse proxy.
+	Enabled bool `yaml:"enabled"`
+	// LoginHeader is the request header containing the authenticated user login.
+	LoginHeader string `yaml:"login_header"`
 }

--- a/internal/config/web.go
+++ b/internal/config/web.go
@@ -28,5 +28,5 @@ type BasicAuthenticationSpec struct {
 
 type AuthProxyAuthenticationSpec struct {
 	// LoginHeader is the request header containing the authenticated user login.
-	LoginHeader string `yaml:"login_header"`
+	LoginHeader string `yaml:"loginHeader"`
 }

--- a/internal/config/web.go
+++ b/internal/config/web.go
@@ -27,8 +27,6 @@ type BasicAuthenticationSpec struct {
 }
 
 type AuthProxyAuthenticationSpec struct {
-	// Enabled enables authentication using a login header set by a trusted reverse proxy.
-	Enabled bool `yaml:"enabled"`
 	// LoginHeader is the request header containing the authenticated user login.
 	LoginHeader string `yaml:"login_header"`
 }

--- a/internal/entrypoints/webserver/authenticator/auth_proxy.go
+++ b/internal/entrypoints/webserver/authenticator/auth_proxy.go
@@ -1,0 +1,35 @@
+package authenticator
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/swarm-deploy/swarm-deploy/internal/security"
+)
+
+type authProxyAuthenticator struct {
+	loginHeader string
+}
+
+func newAuthProxyAuthenticator(loginHeader string) (Authenticator, error) {
+	loginHeader = strings.TrimSpace(loginHeader)
+	if loginHeader == "" {
+		return nil, errors.New("login header is required")
+	}
+
+	return &authProxyAuthenticator{loginHeader: loginHeader}, nil
+}
+
+func (a *authProxyAuthenticator) Authenticate(r *http.Request) (security.User, bool) {
+	login := strings.TrimSpace(r.Header.Get(a.loginHeader))
+	if login == "" {
+		return security.User{}, false
+	}
+
+	return security.User{Name: login}, true
+}
+
+func (*authProxyAuthenticator) Challenge(w http.ResponseWriter) {
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+}

--- a/internal/entrypoints/webserver/authenticator/auth_proxy_test.go
+++ b/internal/entrypoints/webserver/authenticator/auth_proxy_test.go
@@ -1,0 +1,50 @@
+package authenticator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthProxyAuthenticatorAuthenticatesUserFromHeader(t *testing.T) {
+	auth, err := newAuthProxyAuthenticator("X-User-Name")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-User-Name", " developer ")
+
+	user, authenticated := auth.Authenticate(req)
+
+	require.True(t, authenticated)
+	assert.Equal(t, "developer", user.Name)
+}
+
+func TestAuthProxyAuthenticatorRejectsRequestWithoutLoginHeader(t *testing.T) {
+	auth, err := newAuthProxyAuthenticator("X-User-Name")
+	require.NoError(t, err)
+
+	user, authenticated := auth.Authenticate(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.False(t, authenticated)
+	assert.Empty(t, user.Name)
+}
+
+func TestAuthProxyAuthenticatorRequiresLoginHeaderConfiguration(t *testing.T) {
+	auth, err := newAuthProxyAuthenticator(" ")
+
+	require.Error(t, err)
+	assert.Nil(t, auth)
+}
+
+func TestAuthProxyAuthenticatorChallengesWithUnauthorized(t *testing.T) {
+	auth, err := newAuthProxyAuthenticator("X-User-Name")
+	require.NoError(t, err)
+	rec := httptest.NewRecorder()
+
+	auth.Challenge(rec)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/internal/entrypoints/webserver/authenticator/authenticator.go
+++ b/internal/entrypoints/webserver/authenticator/authenticator.go
@@ -16,25 +16,25 @@ type Authenticator interface {
 }
 
 func Create(cfg config.AuthenticationSpec) (Authenticator, error) {
-	if cfg.AuthProxy.Enabled {
+	strategy := cfg.Strategy()
+
+	switch {
+	case cfg.AuthProxy.Enabled:
 		authenticator, err := newAuthProxyAuthenticator(cfg.AuthProxy.LoginHeader)
 		if err != nil {
 			return nil, fmt.Errorf("create auth proxy authenticator: %w", err)
 		}
 		return authenticator, nil
-	}
-
-	switch cfg.Strategy() {
-	case config.AuthenticationStrategyNone:
+	case strategy == config.AuthenticationStrategyNone:
 		//nolint:nilnil // authentication not required
 		return nil, nil
-	case config.AuthenticationStrategyBasic:
+	case strategy == config.AuthenticationStrategyBasic:
 		authenticator, err := newBasicAuthenticator(cfg.Basic.HTPasswdFile)
 		if err != nil {
 			return nil, fmt.Errorf("create basic authenticator: %w", err)
 		}
 		return authenticator, nil
 	default:
-		return nil, fmt.Errorf("unsupported authenticator %q", cfg.Strategy())
+		return nil, fmt.Errorf("unsupported authenticator %q", strategy)
 	}
 }

--- a/internal/entrypoints/webserver/authenticator/authenticator.go
+++ b/internal/entrypoints/webserver/authenticator/authenticator.go
@@ -16,6 +16,14 @@ type Authenticator interface {
 }
 
 func Create(cfg config.AuthenticationSpec) (Authenticator, error) {
+	if cfg.AuthProxy.Enabled {
+		authenticator, err := newAuthProxyAuthenticator(cfg.AuthProxy.LoginHeader)
+		if err != nil {
+			return nil, fmt.Errorf("create auth proxy authenticator: %w", err)
+		}
+		return authenticator, nil
+	}
+
 	switch cfg.Strategy() {
 	case config.AuthenticationStrategyNone:
 		//nolint:nilnil // authentication not required

--- a/internal/entrypoints/webserver/authenticator/authenticator.go
+++ b/internal/entrypoints/webserver/authenticator/authenticator.go
@@ -16,25 +16,23 @@ type Authenticator interface {
 }
 
 func Create(cfg config.AuthenticationSpec) (Authenticator, error) {
-	strategy := cfg.Strategy()
-
-	switch {
-	case cfg.AuthProxy.Enabled:
-		authenticator, err := newAuthProxyAuthenticator(cfg.AuthProxy.LoginHeader)
-		if err != nil {
-			return nil, fmt.Errorf("create auth proxy authenticator: %w", err)
-		}
-		return authenticator, nil
-	case strategy == config.AuthenticationStrategyNone:
+	switch cfg.Strategy() {
+	case config.AuthenticationStrategyNone:
 		//nolint:nilnil // authentication not required
 		return nil, nil
-	case strategy == config.AuthenticationStrategyBasic:
+	case config.AuthenticationStrategyBasic:
 		authenticator, err := newBasicAuthenticator(cfg.Basic.HTPasswdFile)
 		if err != nil {
 			return nil, fmt.Errorf("create basic authenticator: %w", err)
 		}
 		return authenticator, nil
+	case config.AuthenticationStrategyAuthProxy:
+		authenticator, err := newAuthProxyAuthenticator(cfg.AuthProxy.LoginHeader)
+		if err != nil {
+			return nil, fmt.Errorf("create auth proxy authenticator: %w", err)
+		}
+		return authenticator, nil
 	default:
-		return nil, fmt.Errorf("unsupported authenticator %q", strategy)
+		return nil, fmt.Errorf("unsupported authenticator %q", cfg.Strategy())
 	}
 }


### PR DESCRIPTION
Closes #37.

## What changed
- added `web.security.authentication.authProxy` configuration
- added an authenticator that reads the configured login header
- injects the authenticated user through the existing authorization middleware
- returns `401 Unauthorized` when the header is missing or empty
- added unit tests for successful, missing-header, invalid-config, and challenge cases

## Security note
Auth proxy mode must only be enabled when swarm-deploy is reachable exclusively through a trusted reverse proxy that overwrites the configured header.