### PR TITLE
feat(service-catalog): add OpenAPI links from labels

### DIFF
--- a/internal/resources/service/metadata/links.go
+++ b/internal/resources/service/metadata/links.go
@@ -1,6 +1,12 @@
 package metadata
 
-import "github.com/swarm-deploy/swarm-deploy/internal/shared/labelsdict"
+import (
+	"strings"
+
+	"github.com/swarm-deploy/swarm-deploy/internal/shared/labelsdict"
+)
+
+const traefikOpenAPIPathSuffix = ".loadbalancer.apiportal.path"
 
 type LinksResolver struct {
 	sources map[string]string
@@ -10,6 +16,7 @@ func NewLinksResolver() *LinksResolver {
 	return &LinksResolver{
 		sources: map[string]string{
 			labelsdict.GrafanaURL: "Grafana",
+			labelsdict.OpenAPIURL: "OpenAPI",
 		},
 	}
 }
@@ -30,6 +37,17 @@ func (r *LinksResolver) resolveLinks(labels map[string]string) []Link {
 
 		links = append(links, Link{
 			Type: title,
+			URL:  val,
+		})
+	}
+
+	for key, val := range labels {
+		if val == "" || !strings.HasPrefix(key, "traefik.http.services.") || !strings.HasSuffix(key, traefikOpenAPIPathSuffix) {
+			continue
+		}
+
+		links = append(links, Link{
+			Type: "OpenAPI",
 			URL:  val,
 		})
 	}

--- a/internal/resources/service/metadata/links.go
+++ b/internal/resources/service/metadata/links.go
@@ -1,12 +1,6 @@
 package metadata
 
-import (
-	"strings"
-
-	"github.com/swarm-deploy/swarm-deploy/internal/shared/labelsdict"
-)
-
-const traefikOpenAPIPathSuffix = ".loadbalancer.apiportal.path"
+import "github.com/swarm-deploy/swarm-deploy/internal/shared/labelsdict"
 
 type LinksResolver struct {
 	sources map[string]string
@@ -37,17 +31,6 @@ func (r *LinksResolver) resolveLinks(labels map[string]string) []Link {
 
 		links = append(links, Link{
 			Type: title,
-			URL:  val,
-		})
-	}
-
-	for key, val := range labels {
-		if val == "" || !strings.HasPrefix(key, "traefik.http.services.") || !strings.HasSuffix(key, traefikOpenAPIPathSuffix) {
-			continue
-		}
-
-		links = append(links, Link{
-			Type: "OpenAPI",
 			URL:  val,
 		})
 	}

--- a/internal/resources/service/metadata/links_test.go
+++ b/internal/resources/service/metadata/links_test.go
@@ -1,0 +1,54 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/swarm-deploy/swarm-deploy/internal/shared/labelsdict"
+)
+
+func TestLinksResolverResolveOpenAPI(t *testing.T) {
+	resolver := NewLinksResolver()
+
+	cases := []struct {
+		name     string
+		labels   Labels
+		expected []Link
+	}{
+		{
+			name: "swarm deploy label",
+			labels: Labels{
+				Service: map[string]string{
+					labelsdict.OpenAPIURL: "https://api.example.com/openapi.json",
+				},
+			},
+			expected: []Link{{Type: "OpenAPI", URL: "https://api.example.com/openapi.json"}},
+		},
+		{
+			name: "traefik api portal label",
+			labels: Labels{
+				Service: map[string]string{
+					"traefik.http.services.myapi-svc.loadbalancer.apiportal.path": "/openapi.json",
+				},
+			},
+			expected: []Link{{Type: "OpenAPI", URL: "/openapi.json"}},
+		},
+		{
+			name: "traefik api portal label from container",
+			labels: Labels{
+				Container: map[string]string{
+					"traefik.http.services.myapi-svc.loadbalancer.apiportal.path": "/swagger.json",
+				},
+			},
+			expected: []Link{{Type: "OpenAPI", URL: "/swagger.json"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := &Metadata{}
+			resolver.Resolve(tc.labels, meta)
+			assert.ElementsMatch(t, tc.expected, meta.Links)
+		})
+	}
+}

--- a/internal/resources/service/metadata/links_test.go
+++ b/internal/resources/service/metadata/links_test.go
@@ -10,45 +10,15 @@ import (
 func TestLinksResolverResolveOpenAPI(t *testing.T) {
 	resolver := NewLinksResolver()
 
-	cases := []struct {
-		name     string
-		labels   Labels
-		expected []Link
-	}{
-		{
-			name: "swarm deploy label",
-			labels: Labels{
-				Service: map[string]string{
-					labelsdict.OpenAPIURL: "https://api.example.com/openapi.json",
-				},
-			},
-			expected: []Link{{Type: "OpenAPI", URL: "https://api.example.com/openapi.json"}},
+	meta := &Metadata{}
+	resolver.Resolve(Labels{
+		Service: map[string]string{
+			labelsdict.OpenAPIURL: "https://api.example.com/openapi.json",
 		},
-		{
-			name: "traefik api portal label",
-			labels: Labels{
-				Service: map[string]string{
-					"traefik.http.services.myapi-svc.loadbalancer.apiportal.path": "/openapi.json",
-				},
-			},
-			expected: []Link{{Type: "OpenAPI", URL: "/openapi.json"}},
-		},
-		{
-			name: "traefik api portal label from container",
-			labels: Labels{
-				Container: map[string]string{
-					"traefik.http.services.myapi-svc.loadbalancer.apiportal.path": "/swagger.json",
-				},
-			},
-			expected: []Link{{Type: "OpenAPI", URL: "/swagger.json"}},
-		},
-	}
+	}, meta)
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			meta := &Metadata{}
-			resolver.Resolve(tc.labels, meta)
-			assert.ElementsMatch(t, tc.expected, meta.Links)
-		})
-	}
+	assert.Equal(t, []Link{{
+		Type: "OpenAPI",
+		URL:  "https://api.example.com/openapi.json",
+	}}, meta.Links)
 }

--- a/internal/shared/labelsdict/service.go
+++ b/internal/shared/labelsdict/service.go
@@ -12,6 +12,7 @@ const (
 	ServiceDescription = "org.swarm-deploy.service.description"
 
 	GrafanaURL = "org.swarm-deploy.grafana.url"
+	OpenAPIURL = "org.swarm-deploy.service.openapi.url"
 )
 
 func ServiceManaged(labels map[string]string) bool {


### PR DESCRIPTION
Closes #41

## What changed
- add `org.swarm-deploy.service.openapi.url` to the shared label dictionary
- resolve that label as a service-catalog link with type `OpenAPI`
- cover OpenAPI label resolution with a test

Traefik `apiportal.path` labels are intentionally not handled here because they serve a different Traefik-specific purpose rather than declaring service metadata.

## Validation
The branch diff was verified against `master`. This environment does not provide a local GitHub checkout/Go test runner path, so the test suite could not be executed locally; CI should run the repository checks on this PR.